### PR TITLE
Feature for outputing list of URIs as csv. asgs2016 for now

### DIFF
--- a/get-loci-uri-mapping-csv.sh
+++ b/get-loci-uri-mapping-csv.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+python -m pyloci.sparql.generate_loci_uri_to_id_mappings
+
+for i in asgs2016-*.csv; do
+    zip ${i}.zip ${i}
+    md5sum ${i}.zip > ${i}.zip.md5
+done

--- a/pyloci/sparql/generate_loci_uri_to_id_mappings.py
+++ b/pyloci/sparql/generate_loci_uri_to_id_mappings.py
@@ -1,0 +1,48 @@
+from SPARQLWrapper import SPARQLWrapper, JSON
+import json 
+import os
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+from . import util
+
+GRAPHDB_USER = os.getenv("GRAPHDB_USER")
+GRAPHDB_PASSWORD = os.getenv("GRAPHDB_PASSWORD")
+SPARQL_ENDPOINT =  os.getenv("SPARQL_ENDPOINT")
+
+def main():
+    # uncomment the following GRAPHDB_SPARQL and auth variables for test repo
+    #GRAPHDB_SPARQL = GRAPHDB_SPARQL_TEST
+    auth = None
+    # set auth only if .env has credentials
+    if(GRAPHDB_USER != None and GRAPHDB_PASSWORD != None):
+        auth = { 
+            "user" : GRAPHDB_USER,
+            "password" : GRAPHDB_PASSWORD   
+        }
+
+    loci_types = [    
+        ["asgs2016-sa4","<http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4>", "<http://linked.data.gov.au/def/asgs#sa4Code2016>"],
+        ["asgs2016-sa3","<http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3>", "<http://linked.data.gov.au/def/asgs#sa3Code2016>"],
+        ["asgs2016-sa2","<http://linked.data.gov.au/def/asgs#StatisticalAreaLevel2>", "<http://linked.data.gov.au/def/asgs#sa2Maincode2016>"],
+        ["asgs2016-sa1", "<http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1>", "<http://linked.data.gov.au/def/asgs#sa1Maincode2016>"],       
+        ["asgs2016-mb", "<http://linked.data.gov.au/def/asgs#MeshBlock>", "<http://linked.data.gov.au/def/asgs#mbCode2016>"]
+    ]
+
+    count_types = []
+    for curr in loci_types:
+        l = util.query_uri_id_mapping_table(curr[1], curr[2], SPARQL_ENDPOINT, auth=auth)
+        writeListToCsvFile(l, curr[0]+"_uris.csv")
+
+import csv 
+def writeListToCsvFile(l, fname):
+    print("Writing to " + fname + "...")
+    with open(fname, 'w', newline='') as csvfile:
+        w = csv.writer(csvfile)        
+        w.writerow(['id','lociUri'])
+        w.writerows(l)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyloci/sparql/util.py
+++ b/pyloci/sparql/util.py
@@ -606,6 +606,38 @@ def query_mb16cc_relation(regionUri, sparql_endpoint, relationship="geo:sfContai
             )
     return res_list
 
+def query_uri_id_mapping_table(featureTypeUri, idPropertyUri, sparql_endpoint, auth=None):
+    '''Queries loci cache for <id, uri> mappings
+
+    Parameters
+    ----------
+    * featureTypeUri: region used in the from field of the query
+    * idPropertyUri: region used in the from field of the query
+    * sparql_endpoint: which sparql endpoint to use
+    * auth: authentication details, if needed (optional)
+    '''
+    
+    sparql = SPARQLWrapper(sparql_endpoint)
+
+    if auth !=  None:
+        sparql.setCredentials(user=auth['user'], passwd=auth['password'])
+
+    query = '''
+        SELECT ?id ?lociUri WHERE {{
+	        ?lociUri a {featureTypeUri} .
+            ?lociUri {idPropertyUri} ?id .    
+        }}
+        orderby ?id
+    '''.format(featureTypeUri=featureTypeUri, idPropertyUri=idPropertyUri)
+    print(query)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    
+    res_list = []
+    for res in results['results']['bindings']:                
+        res_list.append( [ res['id']['value'], res['lociUri']['value'] ] )
+    return res_list
 
 def validate_uri_syntax(input_str):
     return bool(re.match(r"<http://.+>", input_str))


### PR DESCRIPTION
As part of enabling uptake of Loc-I, this PR provides command line tools to create local-identifier<>URI mappings as a CSV table by querying the Loc-I cache. The intended use of these CSV tables is to allow users to map existing tables/databases/gis data to the Loc-I URIs. 

This PR currently only creates CSV files for asgs2016 and these features:
* SA1
* SA2
* SA3
* SA4
* MB

A bash script is included for convenient zipping and generation of md5 checksums.

Examples of the outputs can be found on https://s3-ap-southeast-2.amazonaws.com/loci-assets/index.html or more specifically 
http://loci-assets.s3-website-ap-southeast-2.amazonaws.com/auto-generated/uri_index/