### PR TITLE
Adding sparql and python wrapper to query out location labels

### DIFF
--- a/pyloci/sparql/query_loci_location_labels.py
+++ b/pyloci/sparql/query_loci_location_labels.py
@@ -1,0 +1,24 @@
+from SPARQLWrapper import SPARQLWrapper, JSON
+import json 
+import os
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+from . import util
+
+GRAPHDB_USER = os.getenv("GRAPHDB_USER")
+GRAPHDB_PASSWORD = os.getenv("GRAPHDB_PASSWORD")
+SPARQL_ENDPOINT =  os.getenv("SPARQL_ENDPOINT")
+
+# uncomment the following GRAPHDB_SPARQL and auth variables for test repo
+#GRAPHDB_SPARQL = GRAPHDB_SPARQL_TEST
+auth = None
+# set auth only if .env has credentials
+if(GRAPHDB_USER != None and GRAPHDB_PASSWORD != None):
+    auth = { 
+        "user" : GRAPHDB_USER,
+        "password" : GRAPHDB_PASSWORD   
+    }
+
+labels = util.query_labels_from_locations(SPARQL_ENDPOINT, auth=auth)
+

--- a/pyloci/sparql/query_loci_location_labels.py
+++ b/pyloci/sparql/query_loci_location_labels.py
@@ -2,13 +2,22 @@ from SPARQLWrapper import SPARQLWrapper, JSON
 import json 
 import os
 from dotenv import load_dotenv, find_dotenv
+import argparse
 load_dotenv(find_dotenv())
+
 
 from . import util
 
 GRAPHDB_USER = os.getenv("GRAPHDB_USER")
 GRAPHDB_PASSWORD = os.getenv("GRAPHDB_PASSWORD")
 SPARQL_ENDPOINT =  os.getenv("SPARQL_ENDPOINT")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--offset", help="offset", type=int, default=0)
+parser.add_argument("--limit", help="limit", type=int, default=100000)
+parser.add_argument("--max", help="max", type=int, default=None)
+args = parser.parse_args()
+
 
 # uncomment the following GRAPHDB_SPARQL and auth variables for test repo
 #GRAPHDB_SPARQL = GRAPHDB_SPARQL_TEST
@@ -20,5 +29,5 @@ if(GRAPHDB_USER != None and GRAPHDB_PASSWORD != None):
         "password" : GRAPHDB_PASSWORD   
     }
 
-labels = util.query_labels_from_locations(SPARQL_ENDPOINT, auth=auth)
+labels = util.query_labels_from_locations(SPARQL_ENDPOINT, auth=auth, offset=args.offset, limit=args.limit, max=args.max)
 

--- a/pyloci/sparql/util.py
+++ b/pyloci/sparql/util.py
@@ -701,7 +701,7 @@ def iterate_query_for_labels_of_location(offset, limit, sparql_endpoint, auth=No
             )
     return res_list
 
-def query_labels_from_locations(sparql_endpoint, auth=None, verbose=False, offset=0, limit=10000, max=None):
+def query_labels_from_locations(sparql_endpoint, auth=None, verbose=False, offset=0, limit=1000000, max=None):
     count = 0
     curr_offset = offset
     #print from here

--- a/pyloci/sparql/util.py
+++ b/pyloci/sparql/util.py
@@ -609,3 +609,123 @@ def query_mb16cc_relation(regionUri, sparql_endpoint, relationship="geo:sfContai
 
 def validate_uri_syntax(input_str):
     return bool(re.match(r"<http://.+>", input_str))
+
+def iterate_query_for_labels_of_location(offset, limit, sparql_endpoint, auth=None, verbose=False):
+    sparql = SPARQLWrapper(sparql_endpoint)
+    if auth !=  None:
+        sparql.setCredentials(user=auth['user'], passwd=auth['password'])
+    query = '''
+        PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+        PREFIX prov: <http://www.w3.org/ns/prov#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX asgs: <http://linked.data.gov.au/def/asgs#> 
+        PREFIX gnaf: <http://linked.data.gov.au/def/gnaf#> 
+        PREFIX reg: <http://purl.org/linked-data/registry#>
+
+        SELECT DISTINCT ?l ?label
+        WHERE {{
+            {{ ?l a geo:Feature }}
+            UNION
+            {{
+                ?c1 rdfs:subClassOf+ geo:Feature .
+                ?l a ?c1 .
+            }}
+            UNION
+            {{
+                ?s1 rdf:subject ?l ;
+                    rdf:predicate rdf:type ;
+                    rdf:object geo:Feature .
+            }}
+            UNION
+            {{ ?l a prov:Location }}
+            UNION
+            {{
+                ?c2 rdfs:subClassOf+ prov:Location .
+                ?l a ?c2 .
+            }}
+            UNION
+            {{
+                ?s2 rdf:subject ?l ;
+                    rdf:predicate rdf:type ;
+                    rdf:object prov:Location .
+            }} .
+            {{
+                ?l asgs:mbCode2016 ?label
+            }}
+            UNION
+            {{
+                ?l asgs:sa3Name2016 ?label
+            }}
+            UNION
+            {{
+                ?l asgs:sa4Name2016 ?label
+            }}
+            UNION
+            {{
+                ?l asgs:label  ?label
+            }}
+            UNION
+            {{
+                ?l asgs:stateName2016 ?label
+            }}
+            UNION
+            {{
+                ?l rdfs:label ?label
+            }}
+            UNION
+            {{
+                ?l  rdfs:comment ?label
+            }}
+            UNION
+            {{
+                ?l  gnaf:hasName ?label
+            }}
+        }}
+        OFFSET {offset}
+        LIMIT {limit}
+    '''.format(offset=offset, limit=limit)
+
+    if verbose:
+        print(query)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    
+    res_list = []
+    for res in results['results']['bindings']:
+        res_list.append( { #?from ?pred ?to ?fromArea ?toArea ?toParent
+                    'location': res['l']['value']  if 'l' in res else None, 
+                    'label': res['label']['value']  if 'label' in res else None, 
+                }
+            )
+    return res_list
+
+def query_labels_from_locations(sparql_endpoint, auth=None, verbose=False, offset=0, limit=10000, max=None):
+    count = 0
+    curr_offset = offset
+    #print from here
+    
+    while(True):
+        res = iterate_query_for_labels_of_location(curr_offset, limit, sparql_endpoint, auth, verbose)
+        res_count = len(res)
+        if res_count > 0:
+            for curr in res:
+                if curr != None:
+                    print('{location}\t{label}'.format(location=curr['location'], label=curr['label'])) 
+                    count = count + 1
+            curr_offset = curr_offset + res_count
+        else:
+            break
+
+        if max != None and count > max:
+            break
+
+        
+            
+
+
+
+    
+    
+    

--- a/tsv2jsonl.sh
+++ b/tsv2jsonl.sh
@@ -1,0 +1,3 @@
+
+cat location_labels2.tsv | jq -c --raw-input --raw-output 'split("\n") | map(split("\t"))  | map( {"location_uri": .[0], "label": .[1]}) | .[0]' | sed 's/\\r//g' > location_labels.jsonl
+


### PR DESCRIPTION
Adding convenience function to query out location labels via paginated SPARQL queries 10000 at a time.

A user can run this to dump out the location labels as a tab-separated values file. 
```
$ python -m pyloci.sparql.query_loci_location_labels > location_labels.tsv
```